### PR TITLE
Ruleset saving and listing

### DIFF
--- a/src/app/api/rulebookApi.ts
+++ b/src/app/api/rulebookApi.ts
@@ -4,17 +4,9 @@ import {
   ActionType,
   ConditionType,
   EventLog,
-  Rule,
-  Source,
+  Ruleset,
   SourceType,
 } from '@app/types';
-export interface SourceResponse {
-  sources: Source[];
-}
-
-export interface RulesResponse {
-  rules: Rule[];
-}
 
 export interface AvailableSourcesResponse {
   sources: SourceType[];
@@ -40,11 +32,9 @@ export interface ActionLogResponse {
   actions: ActionLog[];
 }
 
-const getSources = (): Promise<SourceResponse> =>
-  apiClient<SourceResponse>('sources').then((response) => response.data);
-
-const getRules = (): Promise<RulesResponse> =>
-  apiClient<RulesResponse>('rules').then((response) => response.data);
+export interface RulesetsResponse {
+  rulesets: Ruleset[];
+}
 
 const getAvailableSources = (): Promise<AvailableSourcesResponse> =>
   apiClient<AvailableSourcesResponse>('available-sources').then((response) => response.data);
@@ -54,12 +44,24 @@ const getAvailableConditions = (sourceTypeName: string): Promise<AvailableCondit
     (response) => response.data
   );
 
-const createSource = (source: Source): Promise<SourceResponse> =>
-  apiClient<SourceResponse>({
-    method: 'post',
-    url: 'sources',
-    data: source,
-  }).then((response) => response.data);
+const createRuleset = (
+  requestData: Ruleset,
+  onSuccess: () => void,
+  onError: (e: Error) => void
+): void => {
+  setTimeout(() => {
+    DEMO_RULESETS.push(requestData);
+    onSuccess();
+  }, Math.random() * 1000 + 2000);
+};
+
+const getRulesets = (): Promise<RulesetsResponse> => {
+  return new Promise<RulesetsResponse>((resolve) => {
+    setTimeout(() => {
+      resolve({ rulesets: DEMO_RULESETS });
+    }, 1000);
+  });
+};
 
 const getAvailableActions = (): Promise<AvailableActionsResponse> =>
   apiClient<AvailableActionsResponse>('available-actions').then((response) => response.data);
@@ -74,13 +76,14 @@ const getActionLog = (): Promise<ActionLogResponse> =>
   apiClient<ActionLogResponse>('action-log').then((response) => response.data);
 
 export {
-  getSources,
-  getRules,
   getAvailableSources,
-  createSource,
   getAvailableConditions,
   getAvailableActions,
+  createRuleset,
+  getRulesets,
   getLog,
   getEventLog,
   getActionLog,
 };
+
+const DEMO_RULESETS: Ruleset[] = [];

--- a/src/app/api/rulebookApi.ts
+++ b/src/app/api/rulebookApi.ts
@@ -1,12 +1,5 @@
 import { apiClient } from '@app/api/apiClient';
-import {
-  ActionLog,
-  ActionType,
-  ConditionType,
-  EventLog,
-  Ruleset,
-  SourceType,
-} from '@app/types';
+import { ActionLog, ActionType, ConditionType, EventLog, Ruleset, SourceType } from '@app/types';
 
 export interface AvailableSourcesResponse {
   sources: SourceType[];
@@ -49,19 +42,13 @@ const createRuleset = (
   onSuccess: () => void,
   onError: (e: Error) => void
 ): void => {
-  setTimeout(() => {
-    DEMO_RULESETS.push(requestData);
-    onSuccess();
-  }, Math.random() * 1000 + 2000);
+  apiClient({ method: 'post', url: 'ruleset', data: requestData })
+    .then(() => onSuccess())
+    .catch((e) => onError(e));
 };
 
-const getRulesets = (): Promise<RulesetsResponse> => {
-  return new Promise<RulesetsResponse>((resolve) => {
-    setTimeout(() => {
-      resolve({ rulesets: DEMO_RULESETS });
-    }, 1000);
-  });
-};
+const getRulesets = (): Promise<RulesetsResponse> =>
+  apiClient<RulesetsResponse>('rulesets').then((response) => response.data);
 
 const getAvailableActions = (): Promise<AvailableActionsResponse> =>
   apiClient<AvailableActionsResponse>('available-actions').then((response) => response.data);
@@ -85,5 +72,3 @@ export {
   getEventLog,
   getActionLog,
 };
-
-const DEMO_RULESETS: Ruleset[] = [];

--- a/src/app/pages/NewPipe/NewPipe.tsx
+++ b/src/app/pages/NewPipe/NewPipe.tsx
@@ -10,16 +10,25 @@ import {
   TextContent,
 } from '@patternfly/react-core';
 import { Link, useHistory } from 'react-router-dom';
-import PipeEdit from '@app/pipes/PipeEdit/PipeEdit';
+import PipeEdit, { PipeEditProps } from '@app/pipes/PipeEdit/PipeEdit';
 import {
   getAvailableActions,
   getAvailableConditions,
   getAvailableSources,
+  createRuleset,
 } from '@app/api/rulebookApi';
 
 const NewPipe: FunctionComponent = () => {
   const history = useHistory();
   const goToHome = () => history.push(`/`);
+
+  const handleCreateRuleset: PipeEditProps['createRuleset'] = (requestData, onSuccess, onError) => {
+    const handleSuccess = (): void => {
+      onSuccess();
+      goToHome();
+    };
+    createRuleset(requestData, handleSuccess, onError);
+  };
 
   return (
     <>
@@ -45,8 +54,8 @@ const NewPipe: FunctionComponent = () => {
           getSourceTypes={getAvailableSources}
           getConditionTypes={getAvailableConditions}
           getActionTypes={getAvailableActions}
+          createRuleset={handleCreateRuleset}
           onCancel={goToHome}
-          onCreate={() => alert('TO DO')}
         />
       </PageSection>
     </>

--- a/src/app/pages/Rulebook/Rulebook.tsx
+++ b/src/app/pages/Rulebook/Rulebook.tsx
@@ -1,8 +1,19 @@
 import React, { FunctionComponent } from 'react';
-import { PageSection, PageSectionVariants, TextContent, Text, Card } from '@patternfly/react-core';
+import {
+  PageSection,
+  PageSectionVariants,
+  TextContent,
+  Text,
+  Card,
+  Button,
+  Toolbar,
+  ToolbarContent,
+  ToolbarItem,
+} from '@patternfly/react-core';
 import PipeList from '@app/pipes/PipeList/PipeList';
 import { useQuery } from '@tanstack/react-query';
 import { getRulesets } from '@app/api/rulebookApi';
+import { Link } from 'react-router-dom';
 
 const Rulebook: FunctionComponent = () => {
   const { data } = useQuery({
@@ -10,6 +21,18 @@ const Rulebook: FunctionComponent = () => {
     queryFn: getRulesets,
     refetchInterval: 4000,
   });
+
+  const toolbar = (
+    <Toolbar id="pipes-toolbar">
+      <ToolbarContent>
+        <ToolbarItem>
+          <Link to={`${location.pathname}/new-pipe`}>
+            <Button variant="primary">New Pipe</Button>
+          </Link>
+        </ToolbarItem>
+      </ToolbarContent>
+    </Toolbar>
+  );
 
   return (
     <>
@@ -20,7 +43,7 @@ const Rulebook: FunctionComponent = () => {
       </PageSection>
       <PageSection>
         <Card>
-          <PipeList pipes={data?.rulesets ?? []} />
+          <PipeList pipes={data?.rulesets ?? []} toolbar={toolbar} />
         </Card>
       </PageSection>
     </>

--- a/src/app/pages/Rulebook/Rulebook.tsx
+++ b/src/app/pages/Rulebook/Rulebook.tsx
@@ -1,8 +1,16 @@
 import React, { FunctionComponent } from 'react';
 import { PageSection, PageSectionVariants, TextContent, Text, Card } from '@patternfly/react-core';
 import PipeList from '@app/pipes/PipeList/PipeList';
+import { useQuery } from '@tanstack/react-query';
+import { getRulesets } from '@app/api/rulebookApi';
 
 const Rulebook: FunctionComponent = () => {
+  const { data } = useQuery({
+    queryKey: ['rulesets'],
+    queryFn: getRulesets,
+    refetchInterval: 4000,
+  });
+
   return (
     <>
       <PageSection variant={PageSectionVariants.light}>
@@ -12,7 +20,7 @@ const Rulebook: FunctionComponent = () => {
       </PageSection>
       <PageSection>
         <Card>
-          <PipeList />
+          <PipeList pipes={data?.rulesets ?? []} />
         </Card>
       </PageSection>
     </>

--- a/src/app/pipes/PipeEdit/PipeContextProvider.tsx
+++ b/src/app/pipes/PipeEdit/PipeContextProvider.tsx
@@ -3,13 +3,14 @@ import { useInterpret } from '@xstate/react';
 import { pipeMachine } from '@app/pipes/PipeEdit/pipeMachine';
 import { InterpreterFrom } from 'xstate';
 import { PipeEditProps } from '@app/pipes/PipeEdit/PipeEdit';
+import { prepareRulesetRequest } from '@app/pipes/PipeEdit/pipeUtils';
 
 export const PipeStateContext = createContext({
   pipeService: {} as InterpreterFrom<typeof pipeMachine>,
 });
 type PipeStateProviderProps = Pick<
   PipeEditProps,
-  'getActionTypes' | 'getSourceTypes' | 'getConditionTypes'
+  'getActionTypes' | 'getSourceTypes' | 'getConditionTypes' | 'createRuleset'
 >;
 export const PipeStateProvider: FunctionComponent<PipeStateProviderProps> = (props) => {
   const pipeService = useInterpret(pipeMachine, {
@@ -17,6 +18,19 @@ export const PipeStateProvider: FunctionComponent<PipeStateProviderProps> = (pro
       fetchSourceTypes: props.getSourceTypes,
       fetchConditionTypes: (context) => props.getConditionTypes(context.request.source.source_type),
       fetchActionTypes: props.getActionTypes,
+      createRuleset: (context) => {
+        const { request, selectedCondition } = context;
+        return (send) => {
+          function onSuccess(): void {
+            send('createSuccess');
+          }
+          function onError(error: Error): void {
+            console.log(error);
+          }
+          const data = prepareRulesetRequest(request, selectedCondition);
+          props.createRuleset(data, onSuccess, onError);
+        };
+      },
     },
     devTools: true,
   });

--- a/src/app/pipes/PipeEdit/PipeEdit.tsx
+++ b/src/app/pipes/PipeEdit/PipeEdit.tsx
@@ -6,23 +6,25 @@ import {
   AvailableSourcesResponse,
 } from '@app/api/rulebookApi';
 import PipeWizard from '@app/pipes/PipeEdit/components/PipeWizard';
+import { Ruleset } from '@app/types';
 
 export interface PipeEditProps {
   getSourceTypes: () => Promise<AvailableSourcesResponse>;
   getConditionTypes: (sourceType: string) => Promise<AvailableConditionsResponse>;
   getActionTypes: () => Promise<AvailableActionsResponse>;
+  createRuleset: (data: Ruleset, onSuccess: () => void, onError: (e: Error) => void) => void;
   onCancel: () => void;
-  onCreate: () => void;
 }
 const PipeEdit: FunctionComponent<PipeEditProps> = (props) => {
-  const { getSourceTypes, getConditionTypes, getActionTypes, onCancel, onCreate } = props;
+  const { getSourceTypes, getConditionTypes, getActionTypes, createRuleset, onCancel } = props;
   return (
     <PipeStateProvider
       getSourceTypes={getSourceTypes}
       getConditionTypes={getConditionTypes}
       getActionTypes={getActionTypes}
+      createRuleset={createRuleset}
     >
-      <PipeWizard onCancel={onCancel} onCreate={onCreate} />
+      <PipeWizard onCancel={onCancel} />
     </PipeStateProvider>
   );
 };

--- a/src/app/pipes/PipeEdit/components/ActionEdit.tsx
+++ b/src/app/pipes/PipeEdit/components/ActionEdit.tsx
@@ -13,14 +13,6 @@ import { ExclamationCircleIcon } from '@patternfly/react-icons';
 import { StateFrom } from 'xstate';
 import { pipeMachineType } from '@app/pipes/PipeEdit/pipeMachine';
 
-const submissionSelector = (state: StateFrom<pipeMachineType>) => {
-  return state.hasTag('submitted');
-};
-
-const actionTypeInvalidSelector = (state: StateFrom<pipeMachineType>) => {
-  return state.hasTag('actionTypeInvalid');
-};
-
 const ActionEdit: FunctionComponent = () => {
   const pipeServices = useContext(PipeStateContext);
   const { send } = pipeServices.pipeService;
@@ -37,6 +29,8 @@ const ActionEdit: FunctionComponent = () => {
   );
 
   const isSubmitted = useSelector(pipeServices.pipeService, submissionSelector);
+  const isSaving = useSelector(pipeServices.pipeService, isSavingSelector);
+
   const isActionTypeInvalid = useSelector(pipeServices.pipeService, actionTypeInvalidSelector);
   const actionTypeValidation: FormGroupProps['validated'] =
     isSubmitted && isActionTypeInvalid ? 'error' : 'default';
@@ -68,7 +62,7 @@ const ActionEdit: FunctionComponent = () => {
           id="action-type"
           name="action-type"
           aria-label="Action Type"
-          isDisabled={actionTypes === undefined}
+          isDisabled={actionTypes === undefined || isSaving}
           validated={actionTypeValidation}
         >
           <FormSelectOption
@@ -90,6 +84,7 @@ const ActionEdit: FunctionComponent = () => {
             registerValidation={registerValidateActionConfiguration}
             schema={selectedActionSchema}
             configuration={selectedAction.module_args}
+            readOnly={isSaving}
           />
         )}
     </Form>
@@ -97,3 +92,15 @@ const ActionEdit: FunctionComponent = () => {
 };
 
 export default ActionEdit;
+
+const submissionSelector = (state: StateFrom<pipeMachineType>) => {
+  return state.hasTag('submitted');
+};
+
+const actionTypeInvalidSelector = (state: StateFrom<pipeMachineType>) => {
+  return state.hasTag('actionTypeInvalid');
+};
+
+const isSavingSelector = (state: StateFrom<pipeMachineType>) => {
+  return state.hasTag('saving');
+};

--- a/src/app/pipes/PipeEdit/components/PipeWizard.tsx
+++ b/src/app/pipes/PipeEdit/components/PipeWizard.tsx
@@ -10,11 +10,11 @@ import ConditionEdit from '@app/pipes/PipeEdit/components/ConditionEdit';
 import WizardFinalStepFooter from '@app/pipes/PipeEdit/components/WizardFinalStepFooter';
 import ActionEdit from '@app/pipes/PipeEdit/components/ActionEdit';
 
-type PipeWizardProps = Pick<PipeEditProps, 'onCreate' | 'onCancel'>;
+type PipeWizardProps = Pick<PipeEditProps, 'onCancel'>;
 const PipeWizard: FunctionComponent<PipeWizardProps> = (props) => {
-  const { onCreate, onCancel } = props;
+  const { onCancel } = props;
   const pipeServices = useContext(PipeStateContext);
-
+  const { send } = pipeServices.pipeService;
   const isSubmitted = useSelector(pipeServices.pipeService, submissionSelector);
   const isStepOneInvalid = useSelector(pipeServices.pipeService, stepOneInvalid);
   const isStepTwoInvalid = useSelector(pipeServices.pipeService, stepTwoInvalid);
@@ -22,19 +22,23 @@ const PipeWizard: FunctionComponent<PipeWizardProps> = (props) => {
   const stepOneStatus = isSubmitted && isStepOneInvalid ? 'error' : 'default';
   const stepTwoStatus = isSubmitted && isStepTwoInvalid ? 'error' : 'default';
   const stepThreeStatus = isSubmitted && isStepThreeInvalid ? 'error' : 'default';
+  const isSaving = useSelector(pipeServices.pipeService, isSavingSelector);
 
   const handleSubmit = () => {
-    if (!(isStepOneInvalid || isStepTwoInvalid || isStepThreeInvalid)) {
-      onCreate();
-    }
+    send('submitForm');
   };
 
   return (
     <Wizard height={'100%'} onClose={onCancel} onSave={handleSubmit}>
-      <WizardStep name="Name and Source" id="first-step" status={stepOneStatus}>
+      <WizardStep
+        name="Name and Source"
+        id="first-step"
+        status={stepOneStatus}
+        isDisabled={isSaving}
+      >
         <SourceEdit />
       </WizardStep>
-      <WizardStep name="Condition" id="second-step" status={stepTwoStatus}>
+      <WizardStep name="Condition" id="second-step" status={stepTwoStatus} isDisabled={isSaving}>
         <ConditionEdit />
       </WizardStep>
       <WizardStep
@@ -65,4 +69,8 @@ const stepThreeInvalid = (state: StateFrom<pipeMachineType>) => {
 
 const submissionSelector = (state: StateFrom<pipeMachineType>) => {
   return state.hasTag('submitted');
+};
+
+const isSavingSelector = (state: StateFrom<pipeMachineType>) => {
+  return state.hasTag('saving');
 };

--- a/src/app/pipes/PipeEdit/components/WizardFinalStepFooter.tsx
+++ b/src/app/pipes/PipeEdit/components/WizardFinalStepFooter.tsx
@@ -2,25 +2,25 @@ import React, { FunctionComponent, useContext } from 'react';
 import { useWizardContext, WizardFooterWrapper } from '@patternfly/react-core/next';
 import { PipeStateContext } from '@app/pipes/PipeEdit/PipeContextProvider';
 import { Button } from '@patternfly/react-core';
+import { useSelector } from '@xstate/react';
 
 const WizardFinalStepFooter: FunctionComponent = () => {
   const { goToNextStep, goToPrevStep, close } = useWizardContext();
   const pipeServices = useContext(PipeStateContext);
-  const { send } = pipeServices.pipeService;
+  const isSaving = useSelector(pipeServices.pipeService, (state) => state.hasTag('saving'));
 
   const onNext = () => {
-    send('submitForm');
     goToNextStep();
   };
   return (
     <WizardFooterWrapper>
-      <Button variant="primary" onClick={onNext}>
+      <Button variant="primary" onClick={onNext} isLoading={isSaving} isDisabled={isSaving}>
         Create
       </Button>
-      <Button variant="secondary" onClick={goToPrevStep}>
+      <Button variant="secondary" onClick={goToPrevStep} isDisabled={isSaving}>
         Back
       </Button>
-      <Button variant="link" onClick={close}>
+      <Button variant="link" onClick={close} isDisabled={isSaving}>
         Cancel
       </Button>
     </WizardFooterWrapper>

--- a/src/app/pipes/PipeEdit/pipeMachine.typegen.ts
+++ b/src/app/pipes/PipeEdit/pipeMachine.typegen.ts
@@ -19,19 +19,26 @@ export interface Typegen0 {
       data: unknown;
       __tip: 'See the XState TS docs to learn how to strongly type this.';
     };
+    'done.invoke.saveRuleset': {
+      type: 'done.invoke.saveRuleset';
+      data: unknown;
+      __tip: 'See the XState TS docs to learn how to strongly type this.';
+    };
     'error.platform.getActionTypes': { type: 'error.platform.getActionTypes'; data: unknown };
     'error.platform.getConditionTypes': { type: 'error.platform.getConditionTypes'; data: unknown };
     'error.platform.getSourceTypes': { type: 'error.platform.getSourceTypes'; data: unknown };
+    'error.platform.saveRuleset': { type: 'error.platform.saveRuleset'; data: unknown };
     'xstate.init': { type: 'xstate.init' };
   };
   invokeSrcNameMap: {
+    createRuleset: 'done.invoke.saveRuleset';
     fetchActionTypes: 'done.invoke.getActionTypes';
     fetchConditionTypes: 'done.invoke.getConditionTypes';
     fetchSourceTypes: 'done.invoke.getSourceTypes';
   };
   missingImplementations: {
     actions: never;
-    services: 'fetchSourceTypes' | 'fetchConditionTypes' | 'fetchActionTypes';
+    services: 'fetchSourceTypes' | 'fetchConditionTypes' | 'fetchActionTypes' | 'createRuleset';
     guards: never;
     delays: never;
   };
@@ -48,6 +55,7 @@ export interface Typegen0 {
     setSourceTypes: 'done.invoke.getSourceTypes';
   };
   eventsCausingServices: {
+    createRuleset: 'submitForm';
     fetchActionTypes: 'xstate.init';
     fetchConditionTypes: 'sourceTypeChange';
     fetchSourceTypes: 'xstate.init';
@@ -55,6 +63,7 @@ export interface Typegen0 {
   eventsCausingGuards: {
     isActionTypeValid: '';
     isConditionTypeValid: '';
+    isFormValid: 'submitForm';
     isNameValid: '';
     isSourceTypeValid: '';
   };
@@ -100,6 +109,8 @@ export interface Typegen0 {
     | 'step two.conditionType.validate'
     | 'wizard'
     | 'wizard.idle'
+    | 'wizard.saved'
+    | 'wizard.saving'
     | 'wizard.submitted'
     | {
         'step one'?:
@@ -125,7 +136,7 @@ export interface Typegen0 {
               conditionConfig?: 'idle' | 'invalid' | 'valid' | 'validate';
               conditionType?: 'fetchingConditions' | 'idle' | 'invalid' | 'valid' | 'validate';
             };
-        wizard?: 'idle' | 'submitted';
+        wizard?: 'idle' | 'saved' | 'saving' | 'submitted';
       };
   tags:
     | 'actionTypeInvalid'
@@ -133,6 +144,7 @@ export interface Typegen0 {
     | 'conditionTypeInvalid'
     | 'nameInvalid'
     | 'nameValid'
+    | 'saving'
     | 'sourceTypeInvalid'
     | 'sourceTypeValid'
     | 'stepOneInvalid'

--- a/src/app/pipes/PipeEdit/pipeUtils.ts
+++ b/src/app/pipes/PipeEdit/pipeUtils.ts
@@ -1,0 +1,27 @@
+import { Ruleset } from '@app/types';
+import { PipeMachineContext } from '@app/pipes/PipeEdit/pipeMachine';
+
+export const prepareRulesetRequest = (
+  requestData: PipeMachineContext['request'],
+  selectedCondition: PipeMachineContext['selectedCondition']
+): Ruleset => {
+  const expression = selectedCondition.condition?.condition;
+  const regex = /{([A-Za-z0-9_$]+)}/g;
+  const matches = expression?.match(regex);
+  let condition = expression ?? '';
+
+  matches?.forEach((match) => {
+    const name = match.slice(1, -1);
+    condition = condition.replaceAll(match, selectedCondition?.configuration?.[name]);
+  });
+
+  return {
+    name: requestData.name,
+    source: requestData.source,
+    rule: {
+      name: requestData.name + '_rule',
+      condition: { condition },
+      action: requestData.action,
+    },
+  };
+};

--- a/src/app/pipes/PipeEdit/pipeUtils.ts
+++ b/src/app/pipes/PipeEdit/pipeUtils.ts
@@ -17,11 +17,13 @@ export const prepareRulesetRequest = (
 
   return {
     name: requestData.name,
-    source: requestData.source,
-    rule: {
-      name: requestData.name + '_rule',
-      condition: { condition },
-      action: requestData.action,
-    },
+    sources: [requestData.source],
+    rules: [
+      {
+        name: requestData.name + '_rule',
+        condition: { condition },
+        action: requestData.action,
+      },
+    ],
   };
 };

--- a/src/app/pipes/PipeList/PipeList.tsx
+++ b/src/app/pipes/PipeList/PipeList.tsx
@@ -2,26 +2,61 @@ import React, { FunctionComponent } from 'react';
 import { Button, EmptyState, EmptyStateBody, EmptyStateIcon, Title } from '@patternfly/react-core';
 import { DataSourceIcon } from '@patternfly/react-icons';
 import { Link } from 'react-router-dom';
+import { Ruleset } from '@app/types';
+import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 
-// @TODO: retrieve pipes
+interface PipeListProps {
+  pipes: Ruleset[];
+}
+const PipeList: FunctionComponent<PipeListProps> = (props) => {
+  const { pipes } = props;
 
-const PipeList: FunctionComponent = () => {
+  const columnNames = {
+    name: 'Name',
+    source: 'Source',
+    action: 'Action',
+  };
+
   return (
-    <EmptyState>
-      <EmptyStateIcon icon={DataSourceIcon} />
-      <Title headingLevel="h1" size="lg">
-        No Pipes Yet
-      </Title>
-      <EmptyStateBody>
-        With a Pipe you can retrieve events from a Source and trigger an Action
-        <br /> when a certain Condition applies.
-      </EmptyStateBody>
-      <EmptyStateBody>
-        <Link to={`${location.pathname}/new-pipe`}>
-          <Button variant="primary">New Pipe</Button>
-        </Link>
-      </EmptyStateBody>
-    </EmptyState>
+    <>
+      {pipes.length === 0 && (
+        <EmptyState>
+          <EmptyStateIcon icon={DataSourceIcon} />
+          <Title headingLevel="h1" size="lg">
+            No Pipes Yet
+          </Title>
+          <EmptyStateBody>
+            With a Pipe you can retrieve events from a Source and trigger an Action
+            <br /> when a certain Condition applies.
+          </EmptyStateBody>
+          <EmptyStateBody>
+            <Link to={`${location.pathname}/new-pipe`}>
+              <Button variant="primary">New Pipe</Button>
+            </Link>
+          </EmptyStateBody>
+        </EmptyState>
+      )}
+      {pipes.length > 0 && (
+        <TableComposable aria-label="pipes">
+          <Thead>
+            <Tr>
+              <Th>{columnNames.name}</Th>
+              <Th>{columnNames.source}</Th>
+              <Th>{columnNames.action}</Th>
+            </Tr>
+          </Thead>
+          <Tbody>
+            {pipes.map((row, index) => (
+              <Tr key={`${row.name}-${index}`}>
+                <Td dataLabel={columnNames.name}>{row.name}</Td>
+                <Td dataLabel={columnNames.source}>{row.source.source_type}</Td>
+                <Td dataLabel={columnNames.action}>{row.rule.action.name}</Td>
+              </Tr>
+            ))}
+          </Tbody>
+        </TableComposable>
+      )}
+    </>
   );
 };
 

--- a/src/app/pipes/PipeList/PipeList.tsx
+++ b/src/app/pipes/PipeList/PipeList.tsx
@@ -7,9 +7,10 @@ import { TableComposable, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-tab
 
 interface PipeListProps {
   pipes: Ruleset[];
+  toolbar?: React.ReactNode;
 }
 const PipeList: FunctionComponent<PipeListProps> = (props) => {
-  const { pipes } = props;
+  const { pipes, toolbar } = props;
 
   const columnNames = {
     name: 'Name',
@@ -37,24 +38,27 @@ const PipeList: FunctionComponent<PipeListProps> = (props) => {
         </EmptyState>
       )}
       {pipes.length > 0 && (
-        <TableComposable aria-label="pipes">
-          <Thead>
-            <Tr>
-              <Th>{columnNames.name}</Th>
-              <Th>{columnNames.source}</Th>
-              <Th>{columnNames.action}</Th>
-            </Tr>
-          </Thead>
-          <Tbody>
-            {pipes.map((row, index) => (
-              <Tr key={`${row.name}-${index}`}>
-                <Td dataLabel={columnNames.name}>{row.name}</Td>
-                <Td dataLabel={columnNames.source}>{row.source.source_type}</Td>
-                <Td dataLabel={columnNames.action}>{row.rule.action.name}</Td>
+        <>
+          {toolbar}
+          <TableComposable aria-label="pipes">
+            <Thead>
+              <Tr>
+                <Th>{columnNames.name}</Th>
+                <Th>{columnNames.source}</Th>
+                <Th>{columnNames.action}</Th>
               </Tr>
-            ))}
-          </Tbody>
-        </TableComposable>
+            </Thead>
+            <Tbody>
+              {pipes.map((row, index) => (
+                <Tr key={`${row.name}-${index}`}>
+                  <Td dataLabel={columnNames.name}>{row.name}</Td>
+                  <Td dataLabel={columnNames.source}>{row.sources[0]?.source_type}</Td>
+                  <Td dataLabel={columnNames.action}>{row.rules[0]?.action.name}</Td>
+                </Tr>
+              ))}
+            </Tbody>
+          </TableComposable>
+        </>
       )}
     </>
   );

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -34,6 +34,12 @@ export interface ActionType {
   schema: object;
 }
 
+export interface Ruleset {
+  name: string;
+  source: Source;
+  rule: Rule;
+}
+
 export interface EventLog {
   type: string;
   event: {

--- a/src/app/types.ts
+++ b/src/app/types.ts
@@ -36,8 +36,8 @@ export interface ActionType {
 
 export interface Ruleset {
   name: string;
-  source: Source;
-  rule: Rule;
+  sources: Source[];
+  rules: Rule[];
 }
 
 export interface EventLog {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,7 @@
     "outDir": "dist",
     "module": "esnext",
     "target": "es6",
-    "lib": ["es6", "dom"],
+    "lib": ["esnext", "dom"],
     "sourceMap": true,
     "jsx": "react",
     "moduleResolution": "node",


### PR DESCRIPTION
Plugging the ruleset creation wizard to APIs.

At some point I should also switch from `pipe` to `ruleset` everywhere. I can do it with a dedicated PR. 